### PR TITLE
Add support for subxpath to be extracted from the results of main xpath

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,8 +12,8 @@ def home():
     form = XPathExtractorForm(request.form)
     if request.method == 'POST' and form.validate():
         try:
-            result, html, xpath = form.resolve()
-            form = XPathExtractorForm(html=html, xpath=xpath)
+            result, html, xpath, subxpath = form.resolve()
+            form = XPathExtractorForm(html=html, xpath=xpath, subxpath=subxpath)
             message = 'Found following results:' if result else 'No results.'
         except Exception as ex:
             message = unicode(ex)

--- a/forms.py
+++ b/forms.py
@@ -16,10 +16,12 @@ xpath.setup()
 class XPathExtractorForm(Form):
     xpath = StringField("XPATH", validators=[validators.required()])
     html = TextAreaField("HTML or URL", validators=[validators.required()])
+    subxpath = StringField("Sub-XPATH", validators=[validators.optional()])
 
     def resolve(self):
         html = self.data['html']
         xpath = self.data['xpath']
+        subxpath = self.data['subxpath']
         if re.match('http.*://.*\..*', html):
             headers = {
                 'User-Agent': USER_AGENT
@@ -27,4 +29,11 @@ class XPathExtractorForm(Form):
             resp = requests.get(self.data['html'].strip(), headers=headers)
             if resp.status_code == 200:
                 html = resp.content.decode(resp.encoding)
-        return [x for x in Selector(text=html).xpath(xpath).extract() if x.strip()], html, xpath
+
+        if subxpath:
+            result = [(i, sel.xpath(subxpath).extract())
+                      for (i, sel) in enumerate(Selector(text=html).xpath(xpath), 1)]
+        else:
+            result = [x for x in Selector(text=html).xpath(xpath).extract() if x.strip()]
+
+        return (result, html, xpath, subxpath)

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,6 +35,15 @@
                     {% endfor %}
                 {% endif %}
             </div>
+            <div class="form-group {% if form.subxpath.errors %}has-error{% endif %}">
+                {{ form.subxpath.label }}
+                {{ form.subxpath(class="form-control") }}
+                {% if form.subxpath.errors %}
+                    {% for error in form.subxpath.errors %}
+                        <label class="control-label">{{ error }}</label>
+                    {% endfor %}
+                {% endif %}
+            </div>
             <div class="form-group {% if form.html.errors %}has-error{% endif %}">
                 {{ form.html.label }}
                 {{ form.html(class="form-control code") }}
@@ -53,11 +62,27 @@
             </div>
         {% endif %}
         {% if result %}
-            <ul class="result list-group">
-                {% for line in result %}
-                    <li class="list-group-item">{{ line }}</li>
+            {% if form.subxpath.data %}
+                {% for i, subresults in result %}
+                    <h4>
+                        Results for element {{ i }}
+                        <span class="label label-{{ subresults and "default" or "warning" }}">{{ subresults|length }} found</span>
+                    </h4>
+                    {% if subresults %}
+                        <ul class="result list-group">
+                            {% for line in subresults %}
+                                <li class="list-group-item">{{ line }}</li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
                 {% endfor %}
-            </ul>
+            {% else %}
+                <ul class="result list-group">
+                    {% for line in result %}
+                        <li class="list-group-item">{{ line }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
         {% endif %}
     </div>
 </body>


### PR DESCRIPTION
Hello, Marko! =)

So, here is my proposal for supporting evaluation of sub-XPaths that are evaluated in the context of each result of the main XPath.

The idea is to support the following workflow:

1) User tests a xpath to select a list of elements (posts, articles, etc)
2) User tests a subxpath to select a given information for each element (say, post titles)
3) User tests another subxpath to select a given information for each element (say, post dates)
4) User tests another subxpath to select a given information for each element (say, post links)
5) ...

The proposal is a bit minimal -- if you like the idea, we can improve the UI later on.
Does this look any good?

Thanks!
